### PR TITLE
Update docs for the `years` parameter of `/quotas/search

### DIFF
--- a/source/v2/openapi.yaml
+++ b/source/v2/openapi.yaml
@@ -525,7 +525,19 @@ paths:
           in: path
           required: false
           description: |
-            Retrieve quotas only for this `years`, E.g. '2019'
+            Retrieve quotas only for this collection of `years`. Note: the array of years may be passed in via URL:
+            ```
+            /quotas/search?years[]=2018&years[]=2019
+            ```
+            and via the body of a JSON request:
+            ```
+            {
+              "years": [
+                "2018",
+                "2019"
+              ]
+            }
+            ```
           schema:
             type: array
         - name: page
@@ -551,7 +563,7 @@ paths:
         /api/v2/quotas/search:
           lang: shell
           source: |-
-            curl -X GET https://www.trade-tariff.service.gov.uk/api/v2/quotas/search?goods_nomenclature_item_id=0805102200&geographical_area_id=EG&order_number=091784&status=not_blocked&years\[\]=2018&page=1
+            curl -X GET https://www.trade-tariff.service.gov.uk/api/v2/quotas/search?goods_nomenclature_item_id=0805102200&geographical_area_id=EG&order_number=091784&status=not_blocked&years[]=2018&years[]=2019&page=1
 
 ### Additional Codes
   /additional_codes/search:


### PR DESCRIPTION
The `/quotas/search` endpoint expects the `years` parameter to be an array in the "rails" array parameter format (e.g. the param name + "[]") This change updates the API documentation to add examples of how to pass this parameter as a 1) URL and as a 2) node in the JSON body

### New description in API documents for [/quota/search](http://localhost:4567/reference.html#get-quotas-search-parameters) `years` parameter:

> Retrieve quotas only for this collection of `years`. Note: the array of years may be passed in via URL:
> ```
> /quotas/search?years[]=2018&years[]=2019
> ```
> and via the body of a JSON request:
> ```
> {
>   "years": [
>     "2018",
>     "2019"
>   ]
> }
> ```
> 

Screenshot:

![image](https://user-images.githubusercontent.com/740379/99967658-2d02bb80-2d66-11eb-8102-84b1551b4a46.png)
